### PR TITLE
map_type fixes. mapnik->standard, hide osmarender

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,10 +70,10 @@ a.external:after { content: "\2197";}
 				staticMapLite - simple map for your website
 			</h2>
 			<p>
-				<img src="staticmap.php?center=40.714728,-73.998672&zoom=14&size=865x512&maptype=mapnik" width="865" height="512" /></p>
+				<img src="staticmap.php?center=40.714728,-73.998672&zoom=14&size=865x512&maptype=standard" width="865" height="512" /></p>
 			<p>
 				This image was created using the following simple &lt;img> tag:
-<pre>&lt;img src="staticmap.php?center=40.714728,-73.998672&amp;zoom=14&amp;size=865x512&amp;maptype=mapnik" /&gt;</pre>
+<pre>&lt;img src="staticmap.php?center=40.714728,-73.998672&amp;zoom=14&amp;size=865x512&amp;maptype=standard" /&gt;</pre>
 			</p>
 		</div>
 		<hr />
@@ -83,7 +83,7 @@ a.external:after { content: "\2197";}
 			</h3>
 
 			<p>
-				<img src="staticmap.php?center=40.714728,-73.998672&zoom=14&size=865x512&maptype=mapnik&markers=40.702147,-74.015794,lightblue1|40.711614,-74.012318,lightblue2|40.718217,-73.998284,lightblue3" width="865" height="512" />
+				<img src="staticmap.php?center=40.714728,-73.998672&zoom=14&size=865x512&maptype=standard&markers=40.702147,-74.015794,lightblue1|40.711614,-74.012318,lightblue2|40.718217,-73.998284,lightblue3" width="865" height="512" />
 </p><p>				Add markers by appending them to the image URL:
 <pre>markers=40.702147,-74.015794,lightblue1|40.711614,-74.012318,lightblue2|40.718217,-73.998284,lightblue3</pre>
 			</p>
@@ -96,12 +96,8 @@ a.external:after { content: "\2197";}
 
 			<p>
 				<div style="float:left; margin-right: 10px">
-					<img src="staticmap.php?center=40.714728,-73.998672&zoom=14&size=256x256&maptype=mapnik" width="256" height="256" />
-					<pre>maptype=mapnik</pre>
-				</div>
-				<div style="float:left; margin-right: 10px">
-					<img src="staticmap.php?center=40.714728,-73.998672&zoom=14&size=256x256&maptype=osmarenderer" width="256" height="256" />
-					<pre>maptype=osmarenderer</pre>
+					<img src="staticmap.php?center=40.714728,-73.998672&zoom=14&size=256x256&maptype=standard" width="256" height="256" />
+					<pre>maptype=standard</pre>
 				</div>
 				<div style="float:left; margin-right: 10px">
 					<img src="staticmap.php?center=40.714728,-73.998672&zoom=14&size=256x256&maptype=cycle" width="256" height="256" />

--- a/staticmap.php
+++ b/staticmap.php
@@ -37,9 +37,13 @@ Class staticMapLite
     protected $tileSize = 256;
     protected $tileSrcUrl = array(
 	'standard' => 'http://tile.openstreetmap.org/{Z}/{X}/{Y}.png',
-	'mapnik' => 'http://tile.openstreetmap.org/{Z}/{X}/{Y}.png', /* deprecated alias */
-        'osmarenderer' => 'http://tile.openstreetmap.org/{Z}/{X}/{Y}.png', /* mapped value from discontinued tile server */
         'cycle' => 'http://a.tile.opencyclemap.org/cycle/{Z}/{X}/{Y}.png',
+    );
+
+    // Deprecated map_type values still supported as aliases
+    protected $mapTypeAliases = array(
+	'mapnik' => 'standard',
+	'osmarender' => 'standard'
     );
 
     protected $tileDefaultSrc = 'standard';
@@ -144,7 +148,9 @@ Class staticMapLite
 
         }
         if ($_GET['maptype']) {
-            if (array_key_exists($_GET['maptype'], $this->tileSrcUrl)) $this->maptype = $_GET['maptype'];
+            $mapTypeParam = $_GET['maptype'];
+            if (array_key_exists($mapTypeParam, $this->mapTypeAliases)) $mapTypeParam = $this->mapTypeAliases[$mapTypeParam];
+            if (array_key_exists($mapTypeParam, $this->tileSrcUrl)) $this->maptype = $mapTypeParam;
         }
     }
 

--- a/staticmap.php
+++ b/staticmap.php
@@ -21,7 +21,7 @@
  *
  * USAGE:
  *
- *  staticmap.php?center=40.714728,-73.998672&zoom=14&size=512x512&maptype=mapnik&markers=40.702147,-74.015794,blues|40.711614,-74.012318,greeng|40.718217,-73.998284,redc
+ *  staticmap.php?center=40.714728,-73.998672&zoom=14&size=512x512&maptype=standrd&markers=40.702147,-74.015794,blues|40.711614,-74.012318,greeng|40.718217,-73.998284,redc
  *
  */
 
@@ -35,12 +35,14 @@ Class staticMapLite
     protected $maxHeight = 1024;
 
     protected $tileSize = 256;
-    protected $tileSrcUrl = array('mapnik' => 'http://tile.openstreetmap.org/{Z}/{X}/{Y}.png',
-        'osmarenderer' => 'http://otile1.mqcdn.com/tiles/1.0.0/osm/{Z}/{X}/{Y}.png',
+    protected $tileSrcUrl = array(
+	'standard' => 'http://tile.openstreetmap.org/{Z}/{X}/{Y}.png',
+	'mapnik' => 'http://tile.openstreetmap.org/{Z}/{X}/{Y}.png', /* deprecated alias */
+        'osmarenderer' => 'http://tile.openstreetmap.org/{Z}/{X}/{Y}.png', /* mapped value from discontinued tile server */
         'cycle' => 'http://a.tile.opencyclemap.org/cycle/{Z}/{X}/{Y}.png',
     );
 
-    protected $tileDefaultSrc = 'mapnik';
+    protected $tileDefaultSrc = 'standard';
     protected $markerBaseDir = 'images/markers';
     protected $osmLogo = 'images/osm_logo.png';
 


### PR DESCRIPTION
The map_type 'mapnik' value is badly named. Create a new alias 'standard'
which is now the new default (while the old 'mapnik' value continues to work as
a deprecated value)

'osmarender' has been (badly) mapped to MapQuest open tiles for a while now, so
broken because these were discontinued (as was the original 'osmarender' layer)
Fix maptype=osmarender so it works, by mapping to osm standard, but obviously
this value is also deprecated.

Changes to the intro page to reflect this.

Fixes https://github.com/dfacts/staticmaplite/issues/3

Deployment note: If there's a large cache built up under `../cache/maps/mapnik` that will no longer get used, so you may want to rename that directory as `../cache/maps/standard`  (or maybe you just delete the cache periodically anyway?)